### PR TITLE
feat: t4 - get filename without the extension

### DIFF
--- a/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
+++ b/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
@@ -20,6 +20,7 @@ file_output() {
 PATH_TO_FOLDER="${1}"
 
 files=$(find "${PATH_TO_FOLDER}" -type f)
+#echo $files
 
 for file in ${files}; do
   filename="${file##*/}"
@@ -38,3 +39,4 @@ for file in ${files}; do
 
   file_output "${filename}" "n"
 done
+

--- a/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
+++ b/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
@@ -3,9 +3,9 @@
 # Script should get a folder as an argument and return all files
 # (including in the nested directories) but without the extension
 
-folder=$1
+PATH_TO_FOLDER=$1
 
-files=$(find $folder -type f)
+files=$(find $PATH_TO_FOLDER -type f)
 
 for file in $files; do
   echo "${file%%.*}";

--- a/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
+++ b/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+folder=$1
+
+array_files=$(find $folder -type f)
+
+for file in $array_files; do
+	echo ${file%%.*};
+done

--- a/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
+++ b/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 
+# Script should get a folder as an argument and return all files
+# (including in the nested directories) but without the extension
+
 folder=$1
 
-array_files=$(find $folder -type f)
+files=$(find $folder -type f)
 
-for file in $array_files; do
-	echo ${file%%.*};
+for file in $files; do
+  echo "${file%%.*}";
 done

--- a/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
+++ b/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
@@ -3,10 +3,15 @@
 # Script should get a folder as an argument and return all files
 # (including in the nested directories) but without the extension
 
-PATH_TO_FOLDER=$1
+PATH_TO_FOLDER="$1"
 
-files=$(find $PATH_TO_FOLDER -type f)
+files=$(find "${PATH_TO_FOLDER}" -type f)
 
 for file in $files; do
-  echo "${file%%.*}";
+  if [[ "${file}" == *"/."* && \
+      $(echo "${file##*/}" | tr -cd '.' | wc -m) -eq 1 ]]; then
+    echo "${file}"
+    continue
+  fi
+  echo "${file%.*}";
 done

--- a/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
+++ b/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
@@ -3,15 +3,38 @@
 # Script should get a folder as an argument and return all files
 # (including in the nested directories) but without the extension
 
-PATH_TO_FOLDER="$1"
+# file_output -- concatenation of a file and a path to a file and
+# output the file
+#
+# usage: file_output <FILENAME> <DOT_FLAG>
+#
+file_output() {
+  local file_without_ext=$(echo "${1}" | cut -d. -f 2)
+  if [[ "${2}" == "y" ]]; then
+    echo "${filefolder}/.${file_without_ext}"
+  else
+    echo "${filefolder}/${file_without_ext}"
+  fi
+}
+
+PATH_TO_FOLDER="${1}"
 
 files=$(find "${PATH_TO_FOLDER}" -type f)
 
-for file in $files; do
-  if [[ "${file}" == *"/."* && \
-      $(echo "${file##*/}" | tr -cd '.' | wc -m) -eq 1 ]]; then
-    echo "${file}"
+for file in ${files}; do
+  filename="${file##*/}"
+  filefolder="${file%/*}"
+
+  # Check if the first character of the filename is a dot
+  if [[ "${filename:0:1}" == "." ]]; then
+    # Compare the number of dots in the file name with one
+    if [[ $(echo "${filename}" | tr -cd '\.' | wc -c) -eq 1 ]]; then
+      echo "${filefolder}/${filename}"
+    else
+      file_output "${filename}" "y"
+    fi
     continue
   fi
-  echo "${file%.*}";
+
+  file_output "${filename}" "n"
 done

--- a/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
+++ b/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
@@ -6,23 +6,27 @@
 # file_output -- concatenation of a file and a path to a file and
 # output the file
 #
-# usage: file_output <FILENAME> <DOT_FLAG>
+# usage: file_output <FILENAME> <HAS_DOT>
 #
 file_output() {
-  local file_without_ext=$(echo "${1}" | cut -d. -f 2)
+  local filename="${1}"
   if [[ "${2}" == "y" ]]; then
+    local file_without_ext=$(echo "${filename}" | cut -d. -f 2)
     echo "${filefolder}/.${file_without_ext}"
   else
+    local file_without_ext=$(echo "${filename}" | cut -d. -f 1)
     echo "${filefolder}/${file_without_ext}"
   fi
 }
 
+if [[ "${#}" -ne 1 ]]; then
+  echo "Invalid number of arguments. Please enter exactly one argument."
+  exit
+fi
+
 PATH_TO_FOLDER="${1}"
 
-files=$(find "${PATH_TO_FOLDER}" -type f)
-#echo $files
-
-for file in ${files}; do
+find "${PATH_TO_FOLDER}" -type f | while read file; do
   filename="${file##*/}"
   filefolder="${file%/*}"
 
@@ -39,4 +43,3 @@ for file in ${files}; do
 
   file_output "${filename}" "n"
 done
-


### PR DESCRIPTION
# Summary
## Test Task
**T4 - Get filename without the extension**
Script should get a folder as an argument and return all files (including in the nested directories) but without the extension.

## my results
`./chapter2-l2-t4-files-no-extensions.sh /home/nadya/fig`

**output:**
```
/home/nadya/fig/e
/home/nadya/fig/d
/home/nadya/fig/wer
/home/nadya/fig/qw/asd
/home/nadya/fig/qw/uop
/home/nadya/fig/fds/dfs
/home/nadya/fig/fds/rert/d
/home/nadya/fig/fds/rert/d
/home/nadya/fig/fds/rert/poi
/home/nadya/fig/sss/reter
/home/nadya/fig/sss/wertep
```