### PR TITLE
feat: t7 - get only the filenames

### DIFF
--- a/chapter2/tests/t7/chapter2-l2-t7-get-unique-files.sh
+++ b/chapter2/tests/t7/chapter2-l2-t7-get-unique-files.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Script get a folder as an argument and return a list of all unique files
+# with extensions but without the absolute path
+
+folder=$1
+files=$(find $folder -type f)
+uniq_files=( )
+
+for file in $files; do
+  name_file="${file##*/}"
+  if [[ ! "${uniq_files[0]}" =~ $name_file ]]; then
+    uniq_files+=$name_file
+    echo $name_file
+  fi
+done

--- a/chapter2/tests/t7/chapter2-l2-t7-get-unique-files.sh
+++ b/chapter2/tests/t7/chapter2-l2-t7-get-unique-files.sh
@@ -9,16 +9,7 @@ if [ "${#}" -ne 1 ]; then
 fi
 
 PATH_FOLDER="${1}"
-files=$(find "${PATH_FOLDER}" -type f)
-name_files=()
 
-for file in ${files[@]}; do
-  name_file="${file##*/}"
-  name_files+=("$name_file")
-#  if [[ ! "${uniq_files[0]}" =~ ${name_file} ]]; then
-#    uniq_files+=${name_file}
-#    echo $name_file
-#  fi
-done
-
-echo "${name_files[@]}" | tr ' ' '\n' | sort -u
+find "${PATH_FOLDER}" -type f | while read filename; do
+  echo "${filename##*/}"
+done | sort | uniq

--- a/chapter2/tests/t7/chapter2-l2-t7-get-unique-files.sh
+++ b/chapter2/tests/t7/chapter2-l2-t7-get-unique-files.sh
@@ -3,14 +3,22 @@
 # Script get a folder as an argument and return a list of all unique files
 # with extensions but without the absolute path
 
-folder=$1
-files=$(find $folder -type f)
-uniq_files=( )
+if [ "${#}" -ne 1 ]; then
+  echo "Invalid number of argument. Please enter exactly one argument."
+  exit
+fi
 
-for file in $files; do
+PATH_FOLDER="${1}"
+files=$(find "${PATH_FOLDER}" -type f)
+name_files=()
+
+for file in ${files[@]}; do
   name_file="${file##*/}"
-  if [[ ! "${uniq_files[0]}" =~ $name_file ]]; then
-    uniq_files+=$name_file
-    echo $name_file
-  fi
+  name_files+=("$name_file")
+#  if [[ ! "${uniq_files[0]}" =~ ${name_file} ]]; then
+#    uniq_files+=${name_file}
+#    echo $name_file
+#  fi
 done
+
+echo "${name_files[@]}" | tr ' ' '\n' | sort -u


### PR DESCRIPTION
# Summary
## Test Task
**T7 - Get only the filenames**
Script should get a folder as an argument and return a list of all unique files with extensions but without the absolute path (including in the nested directories). only `-f `option is allowed for the use of `find `command, i.e.: `find /tmp -type f`. Which should find all files in all nested dirs and then process the output by using expansion.

## my results
`./chapter2-l2-t7-get-unique-files.sh ~/fig`

**output:**
```
e.git
wer.txt
d.txt
asd.fjdk
uop.qwert
dfs
d.saqw
poi
reter.git
```