### PR TITLE
feat: t8 - display new tcp listening connections in the range 10000-10100

### DIFF
--- a/chapter2/tests/t8/chapter2-l4-t8-get-tcp-listening-connections.sh
+++ b/chapter2/tests/t8/chapter2-l4-t8-get-tcp-listening-connections.sh
@@ -9,9 +9,9 @@ end_port=10100
 time_out=5
 all_ports=""
 
-while (true); do
+while true; do
   # Get the required ports
-  ports=$(ss -ltnp "( sport ge "${start_port}" && sport le "${end_port}" )")
+  ports=$( ss -ltnp "( sport ge "${start_port}" && sport le "${end_port}" )" )
   # Looking for new ports
   new_port=$( comm -13 <(echo "${all_ports}") <(echo "${ports}") 2> /dev/null )
 

--- a/chapter2/tests/t8/chapter2-l4-t8-get-tcp-listening-connections.sh
+++ b/chapter2/tests/t8/chapter2-l4-t8-get-tcp-listening-connections.sh
@@ -12,13 +12,13 @@ while true; do
   count_ports="${#ports[@]}"
 
   k=4
-  while [[ "$k" -le "$count_ports" ]]; do
+  while [[ "${k}" -le "${count_ports}" ]]; do
     port="${ports[$k]}"
     if ! [[ "${all_ports[@]}" =~ "${port}" ]]; then
       echo "${ports[$k]}" "${ports[$k+1]}"
-      all_ports+="${port}"
+      all_ports+=("${port}")
     fi
-    ((k++)) && ((k++))
+    k="${k}"+2
   done
 
   if [[ "${#all_ports[@]}" -eq 0 ]]; then

--- a/chapter2/tests/t8/chapter2-l4-t8-get-tcp-listening-connections.sh
+++ b/chapter2/tests/t8/chapter2-l4-t8-get-tcp-listening-connections.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# When you launch the script it should initially list all tcp connections in the port
+# range 10000-10100. New found connections should be displayed in the console as soon
+# as they're identified.
+
+ports=()
+all_ports=()
+
+while true; do
+  ports=( $(ss --tcp sport ge 10000 and sport le 10100 | awk '{ print $4,$5,$6,$7 }') )
+  count_ports="${#ports[@]}"
+
+  k=4
+  while [[ "$k" -le "$count_ports" ]]; do
+    port="${ports[$k]}"
+    if ! [[ "${all_ports[@]}" =~ "${port}" ]]; then
+      echo "${ports[$k]}" "${ports[$k+1]}"
+      all_ports+="${port}"
+    fi
+    ((k++)) && ((k++))
+  done
+
+  if [[ "${#all_ports[@]}" -eq 0 ]]; then
+    echo "No TCP listening sockets found bound to ports in 10000-10100 range"
+  fi
+
+  sleep 5
+done

--- a/chapter2/tests/t8/chapter2-l4-t8-get-tcp-listening-connections.sh
+++ b/chapter2/tests/t8/chapter2-l4-t8-get-tcp-listening-connections.sh
@@ -20,7 +20,7 @@ while true; do
   elif ! [[ -z "${new_port}" ]]; then
     unset '$ports[1]'
     # Display ports
-    echo "${ports}" | awk '{print $4,$5,$6,$7}'
+    echo "${new_port}" | awk '{print $4,$5,$6,$7}'
   fi
 
   all_ports="${ports}"

--- a/chapter2/tests/t8/chapter2-l4-t8-get-tcp-listening-connections.sh
+++ b/chapter2/tests/t8/chapter2-l4-t8-get-tcp-listening-connections.sh
@@ -4,11 +4,15 @@
 # range 10000-10100. New found connections should be displayed in the console as soon
 # as they're identified.
 
+START_PORT=10000
+END_PORT=10100
+TIME_OUT=5
+
 ports=()
 all_ports=()
 
 while true; do
-  ports=( $(ss --tcp sport ge 10000 and sport le 10100 | awk '{ print $4,$5,$6,$7 }') )
+  ports=( $(ss -t sport ge "${START_PORT}" and sport le "${END_PORT}" | awk '{ print $4,$5>
   count_ports="${#ports[@]}"
 
   k=4
@@ -19,11 +23,11 @@ while true; do
       all_ports+=("${port}")
     fi
     k="${k}"+2
-  done
+    done
 
   if [[ "${#all_ports[@]}" -eq 0 ]]; then
     echo "No TCP listening sockets found bound to ports in 10000-10100 range"
   fi
 
-  sleep 5
+  sleep "${TIME_OUT}"
 done

--- a/chapter2/tests/t8/chapter2-l4-t8-get-tcp-listening-connections.sh
+++ b/chapter2/tests/t8/chapter2-l4-t8-get-tcp-listening-connections.sh
@@ -12,7 +12,8 @@ ports=()
 all_ports=()
 
 while true; do
-  ports=( $(ss -t sport ge "${START_PORT}" and sport le "${END_PORT}" | awk '{ print $4,$5>
+  ports=( $(ss -t sport ge "${START_PORT}" and sport le "${END_PORT}" \
+    | awk '{ print $4,$5,$6}') )
   count_ports="${#ports[@]}"
 
   k=4
@@ -26,7 +27,7 @@ while true; do
     done
 
   if [[ "${#all_ports[@]}" -eq 0 ]]; then
-    echo "No TCP listening sockets found bound to ports in 10000-10100 range"
+    echo "No TCP listening sockets found bound to ports in ${START_PORT}-${END_PORT} range"
   fi
 
   sleep "${TIME_OUT}"

--- a/chapter2/tests/t8/chapter2-l4-t8-get-tcp-listening-connections.sh
+++ b/chapter2/tests/t8/chapter2-l4-t8-get-tcp-listening-connections.sh
@@ -4,28 +4,25 @@
 # range 10000-10100. New found connections should be displayed in the console as soon
 # as they're identified.
 
-START_PORT=10000
-END_PORT=10100
-TIME_OUT=5
-HEADER_LIST="Local Address:Port      Peer Address:Port"
+start_port=10000
+end_port=10100
+time_out=5
 all_ports=""
 
-while true; do
+while (true); do
   # Get the required ports
-  ports=$( ss -ltnpH "( sport ge ${START_PORT} && sport le ${END_PORT} )" )
+  ports=$(ss -ltnp "( sport ge "${start_port}" && sport le "${end_port}" )")
   # Looking for new ports
-  new_port=$( comm -13 <(echo "${all_ports}") <(echo "${ports}") )
+  new_port=$( comm -13 <(echo "${all_ports}") <(echo "${ports}") 2> /dev/null )
 
-  if [[ -z "${ports}" ]]; then
-    echo "No TCP listening sockets found bound to ports in ${START_PORT}-${END_PORT} range"
-  elif [[ ! -z "${new_port}" ]]; then
-    if [[ -z "${all_ports}" ]]; then
-      echo "${HEADER_LIST}"
-    fi
-    # Display the new port in the table
-    echo "${new_port}" | sed -E "s/[[:space:]]+/ /g" | cut -d' ' -f 4,5 | sed -E "s/ /\t\t/"
+  if [[ "${ports[@]}" == "State Recv-Q Send-Q Local Address:Port Peer Address:PortProcess" ]]; then
+    echo "No TCP listening sockets found bound to ports in ${start_port}-${end_port} range"
+  elif ! [[ -z "${new_port}" ]]; then
+    unset '$ports[1]'
+    # Display ports
+    echo "${ports}" | awk '{print $4,$5,$6,$7}'
   fi
 
   all_ports="${ports}"
-  sleep "${TIME_OUT}"
+  sleep "${time_out}";
 done


### PR DESCRIPTION
# Summary
## Test Task
### t8 - display new tcp listening connections in the range 10000-10100


When you launch the script it should initially list all tcp connections in the port range 10000-10100
New found connections should be displayed in the console as soon as they're identified

**name the file:** `chapter2-l4-t8-get-tcp-listening-connections.sh`

**example of the call:**

I initially ran 2 nginx instances bound to 2 different ports (10000, 10001)

```sh

chapter2-l4-t8-get-tcp-listening-connections.sh
```

**output:**

```
Local Address:Port   Peer Address:Port
127.0.0.1:10000       0.0.0.0:* 
127.0.0.1:10001       0.0.0.0:* 
```

then 10s later I launch another nginx on port 10002, I should immediately get a single line **APPENDED**

```
127.0.0.1:10002       0.0.0.0:* 
```

so in that particular example over time I will get 3 rows

```sh
Local Address:Port   Peer Address:Port
127.0.0.1:10000       0.0.0.0:* 
127.0.0.1:10001       0.0.0.0:* 
127.0.0.1:10002       0.0.0.0:* 
```

If I have NO listening connections in such port range, then I should display "No TCP listening sockets found bound to ports in 10000-10100 range" every N seconds.