### PR TITLE
feat: t3 - find namespaces without the backup

### DIFF
--- a/chapter2/tests/t3/chapter2-t3-velero-eks-diff.sh
+++ b/chapter2/tests/t3/chapter2-t3-velero-eks-diff.sh
@@ -26,7 +26,7 @@ backup_namespaces=$(curl -sSL \
   https://gist.github.com/dmitry-mightydevops/016139747b6cefdc94160607f95ede74/raw/velero.yaml)
 check_file_existence "velero.yaml" "${backup_namespaces}"
 
-kubernetus_namespaces=$(curl -sSL \
+kubernetes_namespaces=$(curl -sSL \
   https://gist.github.com/dmitry-mightydevops/297c4e235b61982f21a0bbbf7319ac24/raw/kubernetes-namespaces.txt)
 check_file_existence "kubernetes-namespaces.txt" "${kubernetes_namespaces}"
 
@@ -35,7 +35,7 @@ configured_ns=( $(echo "$backup_namespaces" | yq ".spec.source.helm.values" \
   | yq ".schedules[].template.includedNamespaces[]" | sort ) )
 
 for conf_ns in "${configured_ns[@]}"; do
-  kubernetus_namespaces="${kubernetus_namespaces[@]/$conf_ns}"
+  kubernetes_namespaces="${kubernetes_namespaces[@]/$conf_ns}"
 done;
 
-echo $kubernetus_namespaces | tr " " "\n"
+echo ${kubernetes_namespaces} | tr " " "\n"

--- a/chapter2/tests/t3/chapter2-t3-velero-eks-diff.sh
+++ b/chapter2/tests/t3/chapter2-t3-velero-eks-diff.sh
@@ -3,19 +3,39 @@
 # The bash script looks for all namespaces in the cluster that have not been configured
 # in the velero manifest. those. operations on sets.
 
-configuration_backups=$(curl -sSL \
+# check_file_existence -- checks for the existence of a file and that it is not empty
+#
+# usage: check_file_existence <FILE_NAME> <FILE_CONTENTS>
+#
+check_file_existence() {
+  local filename="$1"
+  local file=$(echo "$2" | sed 's/\n//')
+
+  if [[ "${file}" = "404: Not Found" ]]; then
+    echo File "${filename}" does not exist at the this link.
+    exit 1
+  fi
+
+  if [[ -s "${file}" ]]; then
+    echo File "${filename}" is empty.
+    exit 1
+  fi
+}
+
+backup_namespaces=$(curl -sSL \
   https://gist.github.com/dmitry-mightydevops/016139747b6cefdc94160607f95ede74/raw/velero.yaml)
-namespaces=$(curl -sSL \
+check_file_existence "velero.yaml" "${backup_namespaces}"
+
+kubernetus_namespaces=$(curl -sSL \
   https://gist.github.com/dmitry-mightydevops/297c4e235b61982f21a0bbbf7319ac24/raw/kubernetes-namespaces.txt)
+check_file_existence "kubernetes-namespaces.txt" "${kubernetes_namespaces}"
 
-echo "${configuration_backups}" | yq ".spec.source.helm.values" \
-  | yq ".schedules[].template.includedNamespaces[]" | sort > configured_ns.txt
+# Retrieve the list of namespaces, sort them and store them in an array
+configured_ns=( $(echo "$backup_namespaces" | yq ".spec.source.helm.values" \
+  | yq ".schedules[].template.includedNamespaces[]" | sort ) )
 
-while read conf_ns; do
-  namespaces="${namespaces[@]/$conf_ns}"
-done < configured_ns.txt
+for conf_ns in "${configured_ns[@]}"; do
+  kubernetus_namespaces="${kubernetus_namespaces[@]/$conf_ns}"
+done;
 
-for namespace in $namespaces; do
-  echo "${namespace}"
-done
-
+echo $kubernetus_namespaces | tr " " "\n"

--- a/chapter2/tests/t3/chapter2-t3-velero-eks-diff.sh
+++ b/chapter2/tests/t3/chapter2-t3-velero-eks-diff.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# The bash script looks for all namespaces in the cluster that have not been configured
+# in the velero manifest. those. operations on sets.
+
+configuration_backups=$(curl -sSL \
+  https://gist.github.com/dmitry-mightydevops/016139747b6cefdc94160607f95ede74/raw/velero.yaml)
+namespaces=$(curl -sSL \
+  https://gist.github.com/dmitry-mightydevops/297c4e235b61982f21a0bbbf7319ac24/raw/kubernetes-namespaces.txt)
+
+echo "${configuration_backups}" | yq ".spec.source.helm.values" \
+  | yq ".schedules[].template.includedNamespaces[]" | sort > configured_ns.txt
+
+while read conf_ns; do
+  namespaces="${namespaces[@]/$conf_ns}"
+done < configured_ns.txt
+
+for namespace in $namespaces; do
+  echo "${namespace}"
+done
+


### PR DESCRIPTION
# Summary
## Test Task
**T3 - Find namespaces without the backup**

We need to come up with a prototype solution that will give us the list of kubernetes namespaces we haven't backed up. We have a special backup manifest that contains the configurationf for the backups. The configuration is in the schedules.[].includedNamespaces block of the file. 

We're supposed to run the following command:
`kubectl get ns -o="custom-columns=NAME:.metadata.name" --no-headers`
that will give us a list of all namespaces in the kubernetes cluster.

Implement the bash script that will find all namespaces in the cluster that has not been configured in the velero manifest. I.e. operation on sets.

**nuances:**
- your bash script should download these 2 gists using `curl` and pass them into stdout of other commands you're using.
- you can use any CLI tool from the distro you're using to calculate the diff between two data blocks and come up with the output above.
- you can use `yq` or `jq cli` if necessary for your ops.


## my results
`./chapter2-t3-velero-eks-diff.sh`

**output:**
```
aacct
aaoa-ari-cleara
arthrexvip
axia
camp-dotnet
camp-python
camp-unity
caregiver
ci-experiments
ci-experiments-apps
commlrning
debug
demo
dev
disvr
dogvr
enrgy
fallon-medica
faroeve
fbmm
firearm
github-inactivity
igntpb
inkus
insights-agent
interesnee
jenkins
kubewatch
macroplate
mailhog
maunf
medvr
metrics-server
nrs
oprs
prfctpt
redis
rma
saritasa-android
saritasa-ios
saritasa-jira-qa-tool
saritasa-php
saritasa-python
saritasa-qa
saritasa-unity
scripta
sgvr
sportsthread
streetparking
tekton-pipelines-experiments
toro
tran
trapi
trivver
utd
utils
velero
vrcatchup
```