### PR TITLE
feat: t9 - display new tcp listening connections in the range 10000-10100 into terminator zsh

### DIFF
--- a/chapter2/tests/t9/chapter2-l4-t9-get-tcp-listening-connections-in-terminator.sh
+++ b/chapter2/tests/t9/chapter2-l4-t9-get-tcp-listening-connections-in-terminator.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# The script should output the ports immediately after the shell is restarted,
+# without restarting the script.
+
+nohup $0 &
+
+ports=()
+all_ports=()
+
+while true; do
+  ports=( $(ss --tcp sport ge 10000 and sport le 10100 | awk '{ print $4,$5,$6,$7 }') )
+  count_ports="${#ports[@]}"
+
+  k=4
+  while [[ "$k" -le "$count_ports" ]]; do
+    port="${ports[$k]}"
+    if ! [[ "${all_ports[@]}" =~ "${port}" ]]; then
+      echo "${ports[$k]}" "${ports[$k+1]}"
+      all_ports+="${port}"
+    fi
+    ((k++)) && ((k++))
+  done
+
+  if [[ "${#all_ports[@]}" -eq 0 ]]; then
+    echo "No TCP listening sockets found bound to ports in 10000-10100 range"
+  fi
+
+  sleep 5
+done
+

--- a/chapter2/tests/t9/chapter2-l4-t9-get-tcp-listening-connections-in-terminator.sh
+++ b/chapter2/tests/t9/chapter2-l4-t9-get-tcp-listening-connections-in-terminator.sh
@@ -13,13 +13,13 @@ while true; do
   count_ports="${#ports[@]}"
 
   k=4
-  while [[ "$k" -le "$count_ports" ]]; do
+  while [[ "${k}" -le "${count_ports}" ]]; do
     port="${ports[$k]}"
     if ! [[ "${all_ports[@]}" =~ "${port}" ]]; then
       echo "${ports[$k]}" "${ports[$k+1]}"
-      all_ports+="${port}"
+      all_ports+=("${port}")
     fi
-    ((k++)) && ((k++))
+    k="${k}"+2
   done
 
   if [[ "${#all_ports[@]}" -eq 0 ]]; then
@@ -28,4 +28,3 @@ while true; do
 
   sleep 5
 done
-


### PR DESCRIPTION
# Summary
## Test Task
**T9 - Display new tcp listening connections in the range 10000-10100 into terminator zsh**

The solution should always output in the open terminator console even if you close and reopen the terminator window.
no args to the shell script. So you run this script. Close the shell/terminator in which you ran this script. Open another terminator/shell (and you don't run another instance of chapter2-l4-t9-get-tcp-listening-connections-in-terminator.sh), run new nginx in a desired port range and immediately get that single line displayed in that new terminator/shell window.