### PR TITLE
feat: compile distroless python3 OOM container

### DIFF
--- a/chapter4/compile-distroless/.hadolint.yaml
+++ b/chapter4/compile-distroless/.hadolint.yaml
@@ -7,3 +7,7 @@ label-schema:
   maintainer: text
   org.website: url
 strict-labels: true
+
+ignored:
+  - DL3049
+  

--- a/chapter4/compile-distroless/.hadolint.yaml
+++ b/chapter4/compile-distroless/.hadolint.yaml
@@ -1,0 +1,9 @@
+override:
+  error:
+    - DL3006
+  info:
+    - DL3045
+label-schema:
+  maintainer: text
+  org.website: url
+strict-labels: true

--- a/chapter4/compile-distroless/.pre-commit-config.yaml
+++ b/chapter4/compile-distroless/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/hadolint/hadolint
+    rev: v2.12.0
+    hooks:
+      - id: hadolint

--- a/chapter4/compile-distroless/Dockerfile
+++ b/chapter4/compile-distroless/Dockerfile
@@ -5,8 +5,9 @@ WORKDIR /memory
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Deploy
-FROM gcr.io/distroless/python3:debug
+FROM gcr.io/distroless/python3:nonroot
 WORKDIR /memory
 COPY --from=build-env /memory .
-COPY --from=build-env /usr/local /usr/local
+COPY --from=build-env /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
+ENV PYTHONPATH=/usr/local/lib/python3.11/site-packages
 ENTRYPOINT [ "python", "memory.py" ]

--- a/chapter4/compile-distroless/Dockerfile
+++ b/chapter4/compile-distroless/Dockerfile
@@ -1,0 +1,12 @@
+# Build
+FROM python:3-slim AS build-env
+COPY testtask /memory
+WORKDIR /memory
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Deploy
+FROM gcr.io/distroless/python3:debug
+WORKDIR /memory
+COPY --from=build-env /memory .
+COPY --from=build-env /usr/local /usr/local
+ENTRYPOINT [ "python", "memory.py" ]

--- a/chapter4/compile-distroless/Makefile
+++ b/chapter4/compile-distroless/Makefile
@@ -1,0 +1,6 @@
+build:
+	docker build . -t memory-test
+
+MEMORY_LIMIT=100M
+run:
+	docker run -m $(MEMORY_LIMIT) --name memory-container memory-test || docker inspect -f '{{.State}}' memory-container

--- a/chapter4/compile-distroless/Makefile
+++ b/chapter4/compile-distroless/Makefile
@@ -2,5 +2,8 @@ build:
 	docker build . -t memory-test
 
 MEMORY_LIMIT=100M
+CONTAINER_NAME=memory-container
 run:
-	docker run -m $(MEMORY_LIMIT) --name memory-container memory-test || docker inspect -f '{{.State}}' memory-container
+	@docker run -m $(MEMORY_LIMIT) --name $(CONTAINER_NAME) memory-test \
+	  || docker inspect -f '{{.State}}' $(CONTAINER_NAME)
+	@docker rm -v memory-container &> /dev/null

--- a/chapter4/compile-distroless/README.md
+++ b/chapter4/compile-distroless/README.md
@@ -1,0 +1,53 @@
+### Build
+Image building:
+```make build
+
+[+] Building 2.5s (15/15) FINISHED                                                                                                                                       
+ => [internal] load .dockerignore                                                                                                                                              0.0s
+ => => transferring context: 2B                                                                                                                                                0.0s
+ => [internal] load build definition from Dockerfile                                                                                                                           0.0s
+ => => transferring dockerfile: 344B                                                                                                                                           0.0s
+ => [internal] load metadata for gcr.io/distroless/python3:debug                                                                                                               1.3s
+ => [internal] load metadata for docker.io/library/python:3-slim                                                                                                               2.5s
+ => [auth] library/python:pull token for registry-1.docker.io                                                                                                                  0.0s
+ => [stage-1 1/4] FROM gcr.io/distroless/python3:debug@sha256:29da1c25f3bfc13a3bc750e875e18587139688472ba5869ad6ff41059d0cdbde                                                 0.0s
+ => [internal] load build context                                                                                                                                              0.0s
+ => => transferring context: 112B                                                                                                                                              0.0s
+ => [build-env 1/4] FROM docker.io/library/python:3-slim@sha256:286f2f1d6f2f730a44108656afb04b131504b610a6cb2f3413918e98dabba67e                                               0.0s
+ => CACHED [stage-1 2/4] WORKDIR /memory                                                                                                                                       0.0s
+ => CACHED [build-env 2/4] COPY testtask /memory                                                                                                                               0.0s
+ => CACHED [build-env 3/4] WORKDIR /memory                                                                                                                                     0.0s
+ => CACHED [build-env 4/4] RUN pip install --no-cache-dir -r requirements.txt                                                                                                  0.0s
+ => CACHED [stage-1 3/4] COPY --from=build-env /memory .                                                                                                                       0.0s
+ => CACHED [stage-1 4/4] COPY --from=build-env /usr/local /usr/local                                                                                                           0.0s
+ => exporting to image                                                                                                                                                         0.0s
+ => => exporting layers                                                                                                                                                        0.0s
+ => => writing image sha256:68547868fd20f6990c13cfa462dd5342f4e31b15597e5a62f8ebbc617901a4ef                                                                                   0.0s
+ => => naming to docker.io/library/memory-test                                                                                                                                 0.0s
+```
+
+### Run
+Run with memory limit:
+```make run memory_limit=100M
+
+Usage over time: [22.19140625, 22.29296875, 36.63671875, 51.22265625, 66.09375, 80.7890625, 95.2265625, 22.4140625]
+Peak usage: 95.2265625
+```
+If there is not enough memory:
+```make run memory_limit=30M
+
+{exited false false false true false 0 137  2023-04-25T10:46:47.347929667Z 2023-04-25T10:46:47.766722563Z <nil>}
+
+```
+
+### Hadolint installation
+Hadolint checks your Dockerfiles.
+```brew install hadolint
+```
+Start check:
+```hadolint Dockerfile
+```
+
+We need to run the following command to pre-commit:
+```pre-commit install
+```

--- a/chapter4/compile-distroless/README.md
+++ b/chapter4/compile-distroless/README.md
@@ -1,6 +1,7 @@
 ### Build
 Image building:
-```make build
+```
+make build
 
 [+] Building 2.5s (15/15) FINISHED                                                                                                                                       
  => [internal] load .dockerignore                                                                                                                                              0.0s
@@ -28,13 +29,15 @@ Image building:
 
 ### Run
 Run with memory limit:
-```make run memory_limit=100M
+```
+make run memory_limit=100M
 
 Usage over time: [22.19140625, 22.29296875, 36.63671875, 51.22265625, 66.09375, 80.7890625, 95.2265625, 22.4140625]
 Peak usage: 95.2265625
 ```
 If there is not enough memory:
-```make run memory_limit=30M
+```
+make run memory_limit=30M
 
 {exited false false false true false 0 137  2023-04-25T10:46:47.347929667Z 2023-04-25T10:46:47.766722563Z <nil>}
 
@@ -42,12 +45,15 @@ If there is not enough memory:
 
 ### Hadolint installation
 Hadolint checks your Dockerfiles.
-```brew install hadolint
+```
+brew install hadolint
 ```
 Start check:
-```hadolint Dockerfile
+```
+hadolint Dockerfile
 ```
 
 We need to run the following command to pre-commit:
-```pre-commit install
+```
+pre-commit install
 ```

--- a/chapter4/compile-distroless/testtask/memory.py
+++ b/chapter4/compile-distroless/testtask/memory.py
@@ -1,0 +1,10 @@
+import array
+from memory_profiler import memory_usage
+
+def allocate(size):
+    some_var = array.array('l', range(size))
+
+usage = memory_usage((allocate, (int(1e7),)))
+peak = max(usage)
+print(f"Usage over time: {usage}")
+print(f"Peak usage: {peak}")

--- a/chapter4/compile-distroless/testtask/requirements.txt
+++ b/chapter4/compile-distroless/testtask/requirements.txt
@@ -1,0 +1,1 @@
+memory_profiler


### PR DESCRIPTION
# Summary
## Test Task
Compile container using distroless base python3 image https://github.com/GoogleContainerTools/distroless

See python files in testtask folder.

What you will need to do:
-  setup pre-commit in the folder to run https://github.com/hadolint/hadolint checks against any Dockerfiles
        don't open any PR if your Dockerfile does not pass validation from the linter.
-  provide README.md with instructions how to run/test your work
-  create Makefile with the following targets:
        - `build`
        - `run`
            `run` target should accept parameter `limit` that will set the desired max memory limit for the running docker container
            if such parameter is not set, a default value of 100m should be used
-  make run should start the docker container and output content similar to
```
    Usage over time: [20.67578125, 20.67578125, 35.30078125, 50.17578125, 64.80078125, 79.55078125, 94.30078125, 20.734375]
    Peak usage: 94.30078125
```
-  make run with optional argument for memory set at 30m should understand that container exited by error and in this case output the following line
```
    {exited false false false true false 0 137  2023-04-17T00:50:11.053754525Z 2023-04-17T00:50:13.721847306Z <nil>}
```
which is content of the docker State value.

## my results
`make run`

**output:**
```
Usage over time: [22.12890625, 22.16796875, 36.51171875, 50.83984375, 65.453125, 79.890625, 94.328125, 22.2890625]
Peak usage: 94.328125
```
`make run MEMORY_LIMIT=110M `

**output:**
```
Usage over time: [20.09765625, 20.16796875, 37.58203125, 54.81640625, 72.41796875, 90.20703125, 20.23046875]
Peak usage: 90.20703125
```
`make run MEMORY_LIMIT=30M`
**output:**
```
{exited false false false true false 0 137  2023-04-25T10:53:29.528821529Z 2023-04-25T10:53:29.967758705Z <nil>}
```