### PR TITLE
feat: buildpacks - slow php reporting page

### DIFF
--- a/chapter4/buildpack-task/.nginx.conf.d/nginx.conf
+++ b/chapter4/buildpack-task/.nginx.conf.d/nginx.conf
@@ -1,0 +1,93 @@
+worker_processes auto;
+daemon off;
+pid /tmp/nginx.pid;
+
+events {
+	worker_connections 1024;
+}
+
+http {
+	sendfile on;
+	tcp_nopush on;
+	access_log off;
+
+	upstream reports-fast {
+		server unix:/tmp/www.sock;
+	}
+
+	upstream reports-slow {
+		server unix:/tmp/slow.sock;
+	}
+
+	server {
+		listen 80;
+		listen [::]:80;
+
+		server_name _;
+		root /workspace/htdocs/reports;
+
+		location /reports/fast {
+			add_header x-server-engine "php";
+
+			fastcgi_intercept_errors on;
+			fastcgi_index index.php;
+			fastcgi_param  QUERY_STRING       $query_string;
+			fastcgi_param  REQUEST_METHOD     $request_method;
+			fastcgi_param  CONTENT_TYPE       $content_type;
+			fastcgi_param  CONTENT_LENGTH     $content_length;
+			fastcgi_param  SCRIPT_NAME        $fastcgi_script_name;
+			fastcgi_param  REQUEST_URI        $request_uri;
+			fastcgi_param  DOCUMENT_URI       $document_uri;
+			fastcgi_param  DOCUMENT_ROOT      $document_root;
+			fastcgi_param  SERVER_PROTOCOL    $server_protocol;
+			fastcgi_param  REQUEST_SCHEME     $scheme;
+			fastcgi_param  HTTPS              $https if_not_empty;
+			fastcgi_param  GATEWAY_INTERFACE  CGI/1.1;
+			fastcgi_param  SERVER_SOFTWARE    nginx/$nginx_version;
+			fastcgi_param  REMOTE_ADDR        $remote_addr;
+			fastcgi_param  REMOTE_PORT        $remote_port;
+			fastcgi_param  SERVER_ADDR        $server_addr;
+			fastcgi_param  SERVER_PORT        $server_port;
+			fastcgi_param  SERVER_NAME        $server_name;
+			fastcgi_param  REDIRECT_STATUS    200;
+			fastcgi_param  PATH_INFO          $fastcgi_path_info;
+			
+			fastcgi_pass   reports-fast;
+			fastcgi_param SCRIPT_FILENAME /workspace/htdocs/reports/fast.php;
+
+			fastcgi_read_timeout 60s;	
+		}
+
+		location /reports/slow {
+			add_header x-server-engine "php";
+
+			fastcgi_intercept_errors on;
+			fastcgi_index index.php;
+			fastcgi_param  QUERY_STRING       $query_string;
+			fastcgi_param  REQUEST_METHOD     $request_method;
+			fastcgi_param  CONTENT_TYPE       $content_type;
+			fastcgi_param  CONTENT_LENGTH     $content_length;
+			fastcgi_param  SCRIPT_NAME        $fastcgi_script_name;
+			fastcgi_param  REQUEST_URI        $request_uri;
+			fastcgi_param  DOCUMENT_URI       $document_uri;
+			fastcgi_param  DOCUMENT_ROOT      $document_root;
+			fastcgi_param  SERVER_PROTOCOL    $server_protocol;
+			fastcgi_param  REQUEST_SCHEME     $scheme;
+			fastcgi_param  HTTPS              $https if_not_empty;
+			fastcgi_param  GATEWAY_INTERFACE  CGI/1.1;
+			fastcgi_param  SERVER_SOFTWARE    nginx/$nginx_version;
+			fastcgi_param  REMOTE_ADDR        $remote_addr;
+			fastcgi_param  REMOTE_PORT        $remote_port;
+			fastcgi_param  SERVER_ADDR        $server_addr;
+			fastcgi_param  SERVER_PORT        $server_port;
+			fastcgi_param  SERVER_NAME        $server_name;
+			fastcgi_param  REDIRECT_STATUS    200;
+			fastcgi_param  PATH_INFO          $fastcgi_path_info;
+			
+			fastcgi_pass reports-slow;
+			fastcgi_param SCRIPT_FILENAME /workspace/htdocs/reports/slow.php;
+
+			fastcgi_read_timeout 600s;
+		}
+	}
+}

--- a/chapter4/buildpack-task/.php.fpm.d/slow.conf
+++ b/chapter4/buildpack-task/.php.fpm.d/slow.conf
@@ -1,0 +1,5 @@
+[slow]
+listen = /tmp/slow.sock
+pm = static
+pm.max_children = 1
+php_admin_value[max_execution_time] = 600s

--- a/chapter4/buildpack-task/.php.fpm.d/www.conf
+++ b/chapter4/buildpack-task/.php.fpm.d/www.conf
@@ -1,0 +1,5 @@
+[www]
+listen = /tmp/www.sock
+pm = static
+pm.max_children = 1
+php_admin_value[max_execution_time] = 60s

--- a/chapter4/buildpack-task/htdocs/reports/fast.php
+++ b/chapter4/buildpack-task/htdocs/reports/fast.php
@@ -1,0 +1,3 @@
+<?php
+  print('FAST REPORT');
+?>

--- a/chapter4/buildpack-task/htdocs/reports/slow.php
+++ b/chapter4/buildpack-task/htdocs/reports/slow.php
@@ -1,0 +1,4 @@
+<?php
+  sleep(600);
+  print('SLOW REPORT');
+?>

--- a/chapter4/buildpack-task/php-fpm.conf
+++ b/chapter4/buildpack-task/php-fpm.conf
@@ -1,0 +1,2 @@
+[global]
+daemonize = no

--- a/chapter4/buildpack-task/project.toml
+++ b/chapter4/buildpack-task/project.toml
@@ -1,0 +1,7 @@
+[[build.env]]
+name = "BP_PHP_SERVER"
+value = "nginx"
+
+[[build.env]]
+name = "PHP_NGINX_PATH"
+value = "/workspace/.nginx.conf.d/nginx.conf"


### PR DESCRIPTION
# Summary
## Test Task
**Buildpacks - slow php reporting page**
You should have finalized your **slow php reporting page** test task defined in `saritasa-devops-camp/chapter3 - tech-stack components/l2/l2 - php.md`

This time you will have to compile OCI image using pack cli and run container that will implement the solution of that task. https://paketo.io/docs/howto/php/

You will need to also use nginx buildpack https://paketo.io/docs/howto/web-servers/ https://paketo.io/docs/reference/nginx-reference/

Use **paketobuildpacks/builder:full** full builder for simplicity.

**Your PR Name:** buildpacks - slow php reporting page
 - Inside your PR - put all files as required by the buildpack, including your PHP files.
 - In summary display a sequence of all CLI calls and outputs.
 - Prove with time curl <URL> that your functionality works as expected.

## my results
`pack build buildpack-task --builder paketobuildpacks/builder:full`

**output:**
`sudo docker run --rm -p 8080:80 buildpack-task`
```
[15-May-2023 05:33:05] NOTICE: [pool www] 'user' directive is ignored when FPM is not running as root
[15-May-2023 05:33:05] NOTICE: [pool www] 'user' directive is ignored when FPM is not running as root
[15-May-2023 05:33:05] NOTICE: [pool www] 'group' directive is ignored when FPM is not running as root
[15-May-2023 05:33:05] NOTICE: [pool www] 'group' directive is ignored when FPM is not running as root
[15-May-2023 05:33:05] NOTICE: fpm is running, pid 24
[15-May-2023 05:33:05] NOTICE: ready to handle connections
2023/05/15 06:01:38 [error] 30#0: *9 open() "/workspace/htdocs/reports/reports/fat" failed (2: No such file or directory), client: 172.17.0.1, server: _, request: "GET /reports/fat HTTP/1.1", host: "localhost:8080"
```

**testing***
`curl -w "\nTime: %{time_total}s\n" http://localhost:8080/reports/fast`
```
FAST REPORT
Time: 0.006209s
```

`curl -w "\nTime: %{time_total}s\n" http://localhost:8080/reports/slow`
```
SLOW REPORT
Time: 600.002032s
```
